### PR TITLE
fix: service_name needs to be a string not an atom

### DIFF
--- a/lib/mix/tasks/deploy.ex
+++ b/lib/mix/tasks/deploy.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Deploy do
 
     app_name = mix_config[:app]
 
-    service_name = app_name
+    service_name = app_name |> to_string()
 
     ext_name =
       app_name


### PR DESCRIPTION
Because otherwise this happens

```elixir
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1

    The following arguments were given to IO.chardata_to_string/1:

        # 1
        :integrations

    Attempted function clauses (showing 2 out of 2):

        def chardata_to_string(string) when is_binary(string)
        def chardata_to_string(list) when is_list(list)

    (elixir 1.14.5) lib/io.ex:670: IO.chardata_to_string/1
    (elixir 1.14.5) lib/path.ex:558: Path.do_join/3
    (elixir 1.14.5) lib/path.ex:550: Path.join/2
    lib/mix/tasks/deploy.ex:202: Mix.Tasks.Deploy.parse_args/1
    lib/mix/tasks/deploy.ex:232: Mix.Tasks.Deploy.Init.run/1
    (mix 1.14.5) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.5) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```