### PR TITLE
fix: ext_name is used in the directory structure

### DIFF
--- a/lib/mix/tasks/deploy.ex
+++ b/lib/mix/tasks/deploy.ex
@@ -25,10 +25,7 @@ defmodule Mix.Tasks.Deploy do
 
     service_name = app_name |> to_string()
 
-    ext_name =
-      app_name
-      |> to_string
-      |> String.replace("_", "-")
+    ext_name = app_name
 
     module_name =
       app_name


### PR DESCRIPTION
The service name is taken from the file e.g. event_store.service so if ext_name has hyphens these won't match up and we'll get errors like

LifecycleEvent - AfterInstall
Script - bin/deploy-extract-release
[stdout]==> Removing previous release /srv/event-store/current [stdout]==> Extracting release from tar file /opt/codedeploy-agent/deployment-root/5b9577ac-428f-4dbf-82ce-79d9fe70d88a/d-7N1LS0I86/deployment-archive/bin/../event_store.tar.gz Script - bin/deploy-set-perms
Script - bin/deploy-enable
[stdout]==> Enabling systemd unit event_store
[stderr]Failed to enable unit: Unit file event_store.service does not exist.